### PR TITLE
feat: add mult and div custom functions

### DIFF
--- a/src/jmespath.js
+++ b/src/jmespath.js
@@ -1475,6 +1475,9 @@
             _func: this._functionContains,
             _signature: [{types: [TYPE_STRING, TYPE_ARRAY, TYPE_NULL]},
                         {types: [TYPE_ANY]}]},
+        div: {
+          _func: this._functionDiv,
+          _signature: [{types: [TYPE_NUMBER, TYPE_NULL]}, {types: [TYPE_NUMBER, TYPE_NULL]}]},
         "ends_with": {
             _func: this._functionEndsWith,
             _signature: [{types: [TYPE_STRING, TYPE_NULL]}, {types: [TYPE_STRING, TYPE_NULL]}]},
@@ -1507,6 +1510,9 @@
           _func: this._functionMinBy,
           _signature: [{types: [TYPE_ARRAY]}, {types: [TYPE_EXPREF]}]
         },
+        mult: {
+          _func: this._functionMult,
+          _signature: [{types: [TYPE_NUMBER, TYPE_NULL]}, {types: [TYPE_NUMBER, TYPE_NULL]}]},
         type: {_func: this._functionType, _signature: [{types: [TYPE_ANY]}]},
         keys: {_func: this._functionKeys, _signature: [{types: [TYPE_OBJECT]}]},
         values: {_func: this._functionValues, _signature: [{types: [TYPE_OBJECT]}]},
@@ -1677,10 +1683,11 @@
     },
 
     _functionAdd: function(resolvedArgs) {
-      var firstArg = getTypeName(resolvedArgs[0]) === TYPE_NULL ? 0 : resolvedArgs[0];
-      var secondArg = getTypeName(resolvedArgs[1]) === TYPE_NULL ? 0 : resolvedArgs[1];
+      if (getTypeName(resolvedArgs[0]) === TYPE_NULL || getTypeName(resolvedArgs[1]) === TYPE_NULL) {
+        return null;
+      }
 
-      return firstArg + secondArg;
+      return resolvedArgs[0] + resolvedArgs[1];
     },
 
     _functionCeil: function(resolvedArgs) {
@@ -1705,6 +1712,14 @@
         }
 
         return resolvedArgs[0].indexOf(resolvedArgs[1]) >= 0;
+    },
+
+    _functionDiv: function(resolvedArgs) {
+      if (getTypeName(resolvedArgs[0]) === TYPE_NULL || getTypeName(resolvedArgs[1]) === TYPE_NULL) {
+        return null;
+      }
+
+      return resolvedArgs[0] / resolvedArgs[1];
     },
 
     _functionFloor: function(resolvedArgs) {
@@ -1787,11 +1802,20 @@
       }
     },
 
-    _functionSub: function(resolvedArgs) {
-      var firstArg = getTypeName(resolvedArgs[0]) === TYPE_NULL ? 0 : resolvedArgs[0];
-      var secondArg = getTypeName(resolvedArgs[1]) === TYPE_NULL ? 0 : resolvedArgs[1];
+    _functionMult: function(resolvedArgs) {
+      if (getTypeName(resolvedArgs[0]) === TYPE_NULL || getTypeName(resolvedArgs[1]) === TYPE_NULL) {
+        return null;
+      }
 
-      return firstArg - secondArg;
+      return resolvedArgs[0] * resolvedArgs[1];
+    },
+
+    _functionSub: function(resolvedArgs) {
+      if (getTypeName(resolvedArgs[0]) === TYPE_NULL || getTypeName(resolvedArgs[1]) === TYPE_NULL) {
+        return null;
+      }
+
+      return resolvedArgs[0] - resolvedArgs[1];
     },
 
     _functionSum: function(resolvedArgs) {

--- a/test/compliance/functions.json
+++ b/test/compliance/functions.json
@@ -61,15 +61,15 @@
     },
     {
       "expression": "add(null_key, `2`)",
-      "result": 2
+      "result": null
     },
     {
       "expression": "add(`1`, null_key)",
-      "result": 1
+      "result": null
     },
     {
       "expression": "add(null_key, null_key)",
-      "result": 0
+      "result": null
     },
     {
       "expression": "unknown_function(`1`, `2`)",
@@ -154,6 +154,22 @@
     {
       "expression": "contains(null_key, null_key)",
       "result": false
+    },
+    {
+      "expression": "div(`6`, `2`)",
+      "result": 3
+    },
+    {
+      "expression": "div(null_key, `2`)",
+      "result": null
+    },
+    {
+      "expression": "div(`6`, null_key)",
+      "result": null
+    },
+    {
+      "expression": "div(null_key, null_key)",
+      "result": null
     },
     {
       "expression": "ends_with(str, 'r')",
@@ -341,15 +357,15 @@
     },
     {
       "expression": "sub(null_key, `3`)",
-      "result": -3
+      "result": null
     },
     {
       "expression": "sub(`5`, null_key)",
-      "result": 5
+      "result": null
     },
     {
       "expression": "sub(null_key, null_key)",
-      "result": 0
+      "result": null
     },
     {
       "expression": "type('abc')",
@@ -454,6 +470,22 @@
     {
       "expression": "join('|', empty_list)",
       "result": ""
+    },
+    {
+      "expression": "mult(`6`, `2`)",
+      "result": 12
+    },
+    {
+      "expression": "mult(null_key, `2`)",
+      "result": null
+    },
+    {
+      "expression": "mult(`6`, null_key)",
+      "result": null
+    },
+    {
+      "expression": "mult(null_key, null_key)",
+      "result": null
     },
     {
       "expression": "reverse(numbers)",


### PR DESCRIPTION
## Conventional Commit

```text
feat: add mult and div custom functions

Converting seconds to/from milliseconds, as is often performed with
Dates via to_number, requires multiplication or division. Align
null behaviors for add and sub to new custom functions.
```

<!--
Follow:
* https://www.conventionalcommits.org/en/v1.0.0-beta.4/
* https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines
* https://www.midori-global.com/blog/2018/04/02/git-50-72-rule
-->
