### PR TITLE
fix: non-scalar types should be made case insensitive with case insensitive flag (ENGCE-23763)

### DIFF
--- a/src/jmespath.js
+++ b/src/jmespath.js
@@ -258,7 +258,7 @@
           }, {});
       }
       default: {
-        return val;
+        return u;
       }
     }
   }

--- a/src/jmespath.js
+++ b/src/jmespath.js
@@ -240,6 +240,29 @@
              ch === "_";
   }
 
+  // Lower case string values, immutably, for scalar and non-scalar types alike.
+  function toCaseInsensitive(u) {
+    switch (getTypeName(u)) {
+      case TYPE_STRING: {
+        return u.toLowerCase();
+      }
+      case TYPE_ARRAY: {
+        return u.map(toCaseInsensitive);
+      }
+      case TYPE_OBJECT: {
+        return Object
+          .entries(u)
+          .reduce((acc, [key, value]) => {
+            acc[key] = toCaseInsensitive(value);
+            return acc;
+          }, {});
+      }
+      default: {
+        return val;
+      }
+    }
+  }
+
   function getTypeName(obj) {
     switch (Object.prototype.toString.call(obj)) {
         case "[object String]":
@@ -1015,12 +1038,9 @@
               var secondTypeName = getTypeName(second);
               var caseInsensitive = this._opts && this._opts.useCaseInsensitiveComparison === true;
 
-              if (caseInsensitive && firstTypeName === TYPE_STRING) {
-                first = first.toLowerCase();
-              }
-
-              if (caseInsensitive && secondTypeName === TYPE_STRING) {
-                second = second.toLowerCase();
+              if (caseInsensitive) {
+                first = toCaseInsensitive(first);
+                second = toCaseInsensitive(second);
               }
 
               switch(node.name) {
@@ -1131,11 +1151,7 @@
               var caseInsensitive = this._opts && this._opts.useCaseInsensitiveComparison === true;
               for (i = 0; i < node.children.length; i++) {
                   var val = this.visit(node.children[i], value);
-                  resolvedArgs.push(
-                    caseInsensitive && getTypeName(val) === TYPE_STRING
-                        ? val.toLowerCase()
-                        : val
-                  );
+                  resolvedArgs.push(caseInsensitive ? toCaseInsensitive(val) : val);
               }
               return this.runtime.callFunction(node.name, resolvedArgs);
             case "ExpressionReference":

--- a/test/jmespath.js
+++ b/test/jmespath.js
@@ -221,6 +221,9 @@ describe('search', function() {
     it('should by default support case sensitive comparison via compatators', function() {
         assert.equal(jmespath.search({foo: 'bar'}, "foo == 'BAR'"), false);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo == 'bar'"), false);
+        assert.equal(jmespath.search({foo: 'bar'}, 'contains(`["BAR"]`, foo)'), false);
+        assert.equal(jmespath.search({foo: 'bar'}, 'contains(`["BAR"]`, foo)'), false);
+        assert.equal(jmespath.search({foo: 'bar'}, '`{"bar": "baz", "qux": 2}`.bar == \'BAZ\''), false);
         assert.equal(jmespath.search({foo: 'bar'}, "foo != 'BAR'"), true);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo != 'bar'"), true);
     });
@@ -228,6 +231,8 @@ describe('search', function() {
         var opts = { useCaseInsensitiveComparison: true };
         assert.equal(jmespath.search({foo: 'bar'}, "foo == 'BAR'", opts), true);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo == 'bar'", opts), true);
+        assert.equal(jmespath.search({foo: 'bar'}, 'contains(`["BAR"]`, foo)', opts), true);
+        assert.equal(jmespath.search({foo: 'bar'}, '`{"bar": "baz", "qux": 2}`.bar == \'BAZ\'', opts), true);
         assert.equal(jmespath.search({foo: 'bar'}, "foo != 'BAR'", opts), false);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo != 'bar'", opts), false);
     });

--- a/test/jmespath.js
+++ b/test/jmespath.js
@@ -222,7 +222,6 @@ describe('search', function() {
         assert.equal(jmespath.search({foo: 'bar'}, "foo == 'BAR'"), false);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo == 'bar'"), false);
         assert.equal(jmespath.search({foo: 'bar'}, 'contains(`["BAR"]`, foo)'), false);
-        assert.equal(jmespath.search({foo: 'bar'}, 'contains(`["BAR"]`, foo)'), false);
         assert.equal(jmespath.search({foo: 'bar'}, '`{"bar": "baz", "qux": 2}`.bar == \'BAZ\''), false);
         assert.equal(jmespath.search({foo: 'bar'}, "foo != 'BAR'"), true);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo != 'bar'"), true);

--- a/test/jmespath.js
+++ b/test/jmespath.js
@@ -225,6 +225,8 @@ describe('search', function() {
         assert.equal(jmespath.search({foo: 'bar'}, '`{"bar": "baz", "qux": 2}`.bar == \'BAZ\''), false);
         assert.equal(jmespath.search({foo: 'bar'}, "foo != 'BAR'"), true);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo != 'bar'"), true);
+        assert.equal(jmespath.search({foo: 2}, 'contains(`[1, 2, 3]`, foo)'), true);
+        assert.equal(jmespath.search({foo: 2}, '`{"bar": 2}`.bar == foo'), true);
     });
     it('should support case insensitive comparison via compatators', function() {
         var opts = { useCaseInsensitiveComparison: true };
@@ -234,6 +236,8 @@ describe('search', function() {
         assert.equal(jmespath.search({foo: 'bar'}, '`{"bar": "baz", "qux": 2}`.bar == \'BAZ\'', opts), true);
         assert.equal(jmespath.search({foo: 'bar'}, "foo != 'BAR'", opts), false);
         assert.equal(jmespath.search({foo: 'BAR'}, "foo != 'bar'", opts), false);
+        assert.equal(jmespath.search({foo: 2}, 'contains(`[1, 2, 3]`, foo)', opts), true);
+        assert.equal(jmespath.search({foo: 2}, '`{"bar": 2}`.bar == foo', opts), true);
     });
     it('should by default support case sensitive comparison via functions', function() {
         assert.equal(jmespath.search({foo: 'bar'}, "starts_with(foo, 'B')"), false);


### PR DESCRIPTION
## Conventional Commit

```text
fix: non-scalar types should be made case insensitive with case insensitive flag (ENGCE-23763)
```

<!--
Follow:
* https://www.conventionalcommits.org/en/v1.0.0-beta.4/
* https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines
* https://www.midori-global.com/blog/2018/04/02/git-50-72-rule
-->
