### PR TITLE
Export compile and tokenize in TypeScript definitions

### DIFF
--- a/src/jmespath.d.ts
+++ b/src/jmespath.d.ts
@@ -14,3 +14,7 @@ export function decorate(fns: Record<string, {_func: Function, _signature: Array
   (query: string) =>
   (jsonDoc: any) =>
   any;
+
+export function compile(query: string): any;
+
+export function tokenize(query: string): any;


### PR DESCRIPTION
  **Summary**

  **The compile function:**
  - Parses a JMESPath expression string into an AST (Abstract Syntax Tree)
  - Already exported in JavaScript at src/jmespath.js:2403
  - Now also exported in TypeScript definitions at src/jmespath.d.ts:18

  **What was changed:**
  Added type definitions for compile and tokenize functions in src/jmespath.d.ts:18-20, so TypeScript users can now properly import and use these functions with type checking.

  Usage example:
  const jmespath = require('@cloudelements/jmespath');

  // Compile an expression to AST
  const ast = jmespath.compile('foo.bar');
